### PR TITLE
認証メールを再送信した際もCustomMessage_SignUpと同様の内容が送信されるように改修

### DIFF
--- a/message/main.go
+++ b/message/main.go
@@ -15,7 +15,7 @@ func handler(request events.CognitoEventUserPoolsCustomMessage) (events.CognitoE
 	}
 
 	// サインアップ時に送られる認証メール
-	if request.TriggerSource == "CustomMessage_SignUp" {
+	if request.TriggerSource == "CustomMessage_SignUp" || request.TriggerSource == "CustomMessage_ResendCode" {
 		signupMessageResponse := events.CognitoEventUserPoolsCustomMessageResponse{
 			SMSMessage: "認証コードは {####} です。",
 			EmailMessage: "メールアドレスを検証するには、次のリンクをクリックしてください。 " +

--- a/message/main_test.go
+++ b/message/main_test.go
@@ -68,6 +68,65 @@ func TestHandler(t *testing.T) {
 		}
 	})
 
+	// TriggerSourceが 'CustomMessage_ResendCode' の場合はCustomMessageが返却される
+	t.Run("Return ResendCode CustomMessage", func(t *testing.T) {
+		cc := &events.CognitoEventUserPoolsCallerContext{
+			AWSSDKVersion: "",
+			ClientID:      "",
+		}
+
+		ch := &events.CognitoEventUserPoolsHeader{
+			Version:       "",
+			TriggerSource: "CustomMessage_ResendCode",
+			Region:        "",
+			UserPoolID:    os.Getenv("TARGET_USER_POOL_ID"),
+			CallerContext: *cc,
+			UserName:      "keitakn",
+		}
+
+		ua := map[string]interface{}{
+			"sub": "dba1d5db-1d94-45b6-8f1b-fad23bb94cd5",
+		}
+
+		cm := map[string]string{
+			"key": "",
+		}
+
+		req := &events.CognitoEventUserPoolsCustomMessageRequest{
+			UserAttributes:    ua,
+			CodeParameter:     "123456789",
+			UsernameParameter: "keitakn",
+			ClientMetadata:    cm,
+		}
+
+		res := &events.CognitoEventUserPoolsCustomMessageResponse{
+			SMSMessage:   "SMSMessage",
+			EmailMessage: "EmailMessage",
+			EmailSubject: "EmailSubject",
+		}
+
+		ev := &events.CognitoEventUserPoolsCustomMessage{
+			CognitoEventUserPoolsHeader: *ch,
+			Request:                     *req,
+			Response:                    *res,
+		}
+
+		handlerResult, err := handler(*ev)
+		if err != nil {
+			t.Fatal("Error failed to trigger with an invalid request", err)
+		}
+
+		expected := &events.CognitoEventUserPoolsCustomMessageResponse{
+			SMSMessage:   "認証コードは {####} です。",
+			EmailMessage: "メールアドレスを検証するには、次のリンクをクリックしてください。 http://localhost:3900/cognito/signup/confirm?code=123456789&sub=keitakn",
+			EmailSubject: "サインアップ メールアドレスの確認をお願いします。",
+		}
+
+		if reflect.DeepEqual(&handlerResult.Response, expected) == false {
+			t.Error("\nActually: ", &handlerResult.Response, "\nExpected: ", expected)
+		}
+	})
+
 	// TriggerSourceが 'CustomMessage_SignUp' だがUserPoolIDが一致しないのでDefaultのメッセージが返却される
 	t.Run("Return Signup DefaultMessage Because the UserPoolID doesn't match", func(t *testing.T) {
 		cc := &events.CognitoEventUserPoolsCallerContext{
@@ -78,6 +137,65 @@ func TestHandler(t *testing.T) {
 		ch := &events.CognitoEventUserPoolsHeader{
 			Version:       "",
 			TriggerSource: "CustomMessage_SignUp",
+			Region:        "",
+			UserPoolID:    "OtherUserPoolID",
+			CallerContext: *cc,
+			UserName:      "keitakn",
+		}
+
+		ua := map[string]interface{}{
+			"sub": "dba1d5db-1d94-45b6-8f1b-fad23bb94cd5",
+		}
+
+		cm := map[string]string{
+			"key": "",
+		}
+
+		req := &events.CognitoEventUserPoolsCustomMessageRequest{
+			UserAttributes:    ua,
+			CodeParameter:     "123456789",
+			UsernameParameter: "keitakn",
+			ClientMetadata:    cm,
+		}
+
+		res := &events.CognitoEventUserPoolsCustomMessageResponse{
+			SMSMessage:   "SMSMessage",
+			EmailMessage: "EmailMessage",
+			EmailSubject: "EmailSubject",
+		}
+
+		ev := &events.CognitoEventUserPoolsCustomMessage{
+			CognitoEventUserPoolsHeader: *ch,
+			Request:                     *req,
+			Response:                    *res,
+		}
+
+		handlerResult, err := handler(*ev)
+		if err != nil {
+			t.Fatal("Error failed to trigger with an invalid request", err)
+		}
+
+		expected := &events.CognitoEventUserPoolsCustomMessageResponse{
+			SMSMessage:   "SMSMessage",
+			EmailMessage: "EmailMessage",
+			EmailSubject: "EmailSubject",
+		}
+
+		if reflect.DeepEqual(&handlerResult.Response, expected) == false {
+			t.Error("\nActually: ", &handlerResult.Response, "\nExpected: ", expected)
+		}
+	})
+
+	// TriggerSourceが 'CustomMessage_ResendCode' だがUserPoolIDが一致しないのでDefaultのメッセージが返却される
+	t.Run("Return ResendCode DefaultMessage Because the UserPoolID doesn't match", func(t *testing.T) {
+		cc := &events.CognitoEventUserPoolsCallerContext{
+			AWSSDKVersion: "",
+			ClientID:      "",
+		}
+
+		ch := &events.CognitoEventUserPoolsHeader{
+			Version:       "",
+			TriggerSource: "CustomMessage_ResendCode",
 			Region:        "",
 			UserPoolID:    "OtherUserPoolID",
 			CallerContext: *cc,


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/8

# やった事
CognitoUserPoolに登録済のユーザーが認証メールを再送するパターンに備えて `CustomMessage_ResendCode` でもサインアップと同じメッセージ内容を設定するように変更。