### PR TITLE
カスタムメッセージのLambda関数をHTMLTemplateを利用するように改修

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 build:
 	GOOS=linux GOARCH=amd64 go build -o bin/message ./message
 	chmod +x bin/message
+	cp message/signup-template.html bin/signup-template.html
 
 clean:
 	rm -rf ./bin

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build:
 	GOOS=linux GOARCH=amd64 go build -o bin/message ./message
 	chmod +x bin/message
 	cp message/signup-template.html bin/signup-template.html
+	cp message/forgot-password-template.html bin/forgot-password-template.html
 
 clean:
 	rm -rf ./bin

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ remove:
 	npm run remove
 
 test:
-	go test -v ./...
+	go test -v $$(go list ./... | grep -v /node_modules/)
 
 format:
 	gofmt -l -s -w .

--- a/infrastructure/helper.go
+++ b/infrastructure/helper.go
@@ -1,0 +1,24 @@
+package infrastructure
+
+import (
+	"flag"
+	"strconv"
+	"testing"
+)
+
+func IsTestRun() bool {
+	testing.Init()
+	flag.Parse()
+	flg := flag.Lookup("test.v")
+	if flg != nil {
+		test, err := strconv.ParseBool(flg.Value.String())
+		if err != nil {
+			panic(err.Error())
+		}
+		if test {
+			return true
+		}
+	}
+
+	return false
+}

--- a/message/forgot-password-template.html
+++ b/message/forgot-password-template.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>パスワードリセット</title>
+</head>
+<body>
+  <p>🐱次のリンクをクリックして、パスワードのリセットを完了させて下さい。🐱</p>
+  <p>{{.ConfirmUrl}}</p>
+</body>
+</html>

--- a/message/main.go
+++ b/message/main.go
@@ -1,10 +1,41 @@
 package main
 
 import (
+	"bytes"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/keitakn/go-cognito-lambda/infrastructure"
+	"html/template"
+	"log"
 	"os"
 )
+
+var templates *template.Template
+
+func init() {
+	signupTemplatePath := "bin/signup-template.html"
+	if infrastructure.IsTestRun() {
+		currentDir, _ := os.Getwd()
+		signupTemplatePath = currentDir + "/signup-template.html"
+	}
+
+	templates = template.Must(template.ParseFiles(signupTemplatePath))
+}
+
+type SignupMessage struct {
+	ConfirmUrl string
+}
+
+func BuildSignupMessage(sm SignupMessage) (*bytes.Buffer, error) {
+	var bodyBuffer bytes.Buffer
+
+	err := templates.ExecuteTemplate(&bodyBuffer, "signup-template.html", sm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bodyBuffer, nil
+}
 
 func handler(request events.CognitoEventUserPoolsCustomMessage) (events.CognitoEventUserPoolsCustomMessage, error) {
 	targetUserPoolId := os.Getenv("TARGET_USER_POOL_ID")
@@ -16,10 +47,19 @@ func handler(request events.CognitoEventUserPoolsCustomMessage) (events.CognitoE
 
 	// サインアップ時に送られる認証メール
 	if request.TriggerSource == "CustomMessage_SignUp" || request.TriggerSource == "CustomMessage_ResendCode" {
+		sm := SignupMessage{
+			ConfirmUrl: "http://localhost:3900/cognito/signup/confirm?code=" + request.Request.CodeParameter + "&sub=" + request.UserName,
+		}
+
+		body, err := BuildSignupMessage(sm)
+		if err != nil {
+			// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
+			log.Fatalln(err)
+		}
+
 		signupMessageResponse := events.CognitoEventUserPoolsCustomMessageResponse{
-			SMSMessage: "認証コードは {####} です。",
-			EmailMessage: "メールアドレスを検証するには、次のリンクをクリックしてください。 " +
-				"http://localhost:3900/cognito/signup/confirm?code=" + request.Request.CodeParameter + "&sub=" + request.UserName,
+			SMSMessage:   "認証コードは {####} です。",
+			EmailMessage: body.String(),
 			EmailSubject: "サインアップ メールアドレスの確認をお願いします。",
 		}
 

--- a/message/main.go
+++ b/message/main.go
@@ -14,15 +14,21 @@ var templates *template.Template
 
 func init() {
 	signupTemplatePath := "bin/signup-template.html"
+	forgotPasswordTemplatePath := "bin/forgot-password-template.html"
 	if infrastructure.IsTestRun() {
 		currentDir, _ := os.Getwd()
 		signupTemplatePath = currentDir + "/signup-template.html"
+		forgotPasswordTemplatePath = currentDir + "/forgot-password-template.html"
 	}
 
-	templates = template.Must(template.ParseFiles(signupTemplatePath))
+	templates = template.Must(template.ParseFiles(signupTemplatePath, forgotPasswordTemplatePath))
 }
 
 type SignupMessage struct {
+	ConfirmUrl string
+}
+
+type ForgotPasswordMessage struct {
 	ConfirmUrl string
 }
 
@@ -30,6 +36,17 @@ func BuildSignupMessage(sm SignupMessage) (*bytes.Buffer, error) {
 	var bodyBuffer bytes.Buffer
 
 	err := templates.ExecuteTemplate(&bodyBuffer, "signup-template.html", sm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bodyBuffer, nil
+}
+
+func BuildForgotPasswordMessage(fm ForgotPasswordMessage) (*bytes.Buffer, error) {
+	var bodyBuffer bytes.Buffer
+
+	err := templates.ExecuteTemplate(&bodyBuffer, "forgot-password-template.html", fm)
 	if err != nil {
 		return nil, err
 	}
@@ -67,10 +84,19 @@ func handler(request events.CognitoEventUserPoolsCustomMessage) (events.CognitoE
 	}
 
 	if request.TriggerSource == "CustomMessage_ForgotPassword" {
+		fm := ForgotPasswordMessage{
+			ConfirmUrl: "http://localhost:3900/cognito/password/reset/confirm?code=" + request.Request.CodeParameter + "&sub=" + request.UserName,
+		}
+
+		body, err := BuildForgotPasswordMessage(fm)
+		if err != nil {
+			// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
+			log.Fatalln(err)
+		}
+
 		forgotPasswordMessageResponse := events.CognitoEventUserPoolsCustomMessageResponse{
-			SMSMessage: "認証コードは {####} です。",
-			EmailMessage: "次のリンクをクリックして、パスワードのリセットを完了させて下さい。 " +
-				"http://localhost:3900/cognito/password/reset/confirm?code=" + request.Request.CodeParameter + "&sub=" + request.UserName,
+			SMSMessage:   "認証コードは {####} です。",
+			EmailMessage: body.String(),
 			EmailSubject: "パスワードをリセットします。",
 		}
 

--- a/message/main_test.go
+++ b/message/main_test.go
@@ -28,6 +28,24 @@ func createExpectedSignUpMessage(sm SignupMessage) (*bytes.Buffer, error) {
 	return &bodyBuffer, nil
 }
 
+// ForgotPasswordMessageカスタムメッセージのテスト用期待値を作成する
+func createExpectedForgotPasswordMessageMessage(fm ForgotPasswordMessage) (*bytes.Buffer, error) {
+	t := template.New("forgot-password-template.html")
+
+	currentDir, _ := os.Getwd()
+	templatePath := currentDir + "/forgot-password-template.html"
+
+	templates := template.Must(t.ParseFiles(templatePath))
+
+	var bodyBuffer bytes.Buffer
+	err := templates.Execute(&bodyBuffer, fm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bodyBuffer, nil
+}
+
 func TestHandler(t *testing.T) {
 	// TriggerSourceが 'CustomMessage_SignUp' の場合はCustomMessageが返却される
 	t.Run("Return Signup CustomMessage", func(t *testing.T) {
@@ -209,9 +227,16 @@ func TestHandler(t *testing.T) {
 			t.Fatal("Error failed to trigger with an invalid request", err)
 		}
 
+		fm := ForgotPasswordMessage{ConfirmUrl: "http://localhost:3900/cognito/password/reset/confirm?code=123456789&sub=keitakn"}
+
+		body, err := createExpectedForgotPasswordMessageMessage(fm)
+		if err != nil {
+			t.Fatal("Error Failed to parse HTML Template", err)
+		}
+
 		expected := &events.CognitoEventUserPoolsCustomMessageResponse{
 			SMSMessage:   "認証コードは {####} です。",
-			EmailMessage: "次のリンクをクリックして、パスワードのリセットを完了させて下さい。 http://localhost:3900/cognito/password/reset/confirm?code=123456789&sub=keitakn",
+			EmailMessage: body.String(),
 			EmailSubject: "パスワードをリセットします。",
 		}
 

--- a/message/main_test.go
+++ b/message/main_test.go
@@ -1,12 +1,32 @@
 package main
 
 import (
+	"bytes"
+	"html/template"
 	"os"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
 )
+
+// SignUpカスタムメッセージのテスト用期待値を作成する
+func createExpectedSignUpMessage(sm SignupMessage) (*bytes.Buffer, error) {
+	t := template.New("signup-template.html")
+
+	currentDir, _ := os.Getwd()
+	templatePath := currentDir + "/signup-template.html"
+
+	templates := template.Must(t.ParseFiles(templatePath))
+
+	var bodyBuffer bytes.Buffer
+	err := templates.Execute(&bodyBuffer, sm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bodyBuffer, nil
+}
 
 func TestHandler(t *testing.T) {
 	// TriggerSourceが 'CustomMessage_SignUp' の場合はCustomMessageが返却される
@@ -57,9 +77,16 @@ func TestHandler(t *testing.T) {
 			t.Fatal("Error failed to trigger with an invalid request", err)
 		}
 
+		sm := SignupMessage{ConfirmUrl: "http://localhost:3900/cognito/signup/confirm?code=123456789&sub=keitakn"}
+
+		body, err := createExpectedSignUpMessage(sm)
+		if err != nil {
+			t.Fatal("Error Failed to parse HTML Template", err)
+		}
+
 		expected := &events.CognitoEventUserPoolsCustomMessageResponse{
 			SMSMessage:   "認証コードは {####} です。",
-			EmailMessage: "メールアドレスを検証するには、次のリンクをクリックしてください。 http://localhost:3900/cognito/signup/confirm?code=123456789&sub=keitakn",
+			EmailMessage: body.String(),
 			EmailSubject: "サインアップ メールアドレスの確認をお願いします。",
 		}
 
@@ -116,9 +143,16 @@ func TestHandler(t *testing.T) {
 			t.Fatal("Error failed to trigger with an invalid request", err)
 		}
 
+		sm := SignupMessage{ConfirmUrl: "http://localhost:3900/cognito/signup/confirm?code=123456789&sub=keitakn"}
+
+		body, err := createExpectedSignUpMessage(sm)
+		if err != nil {
+			t.Fatal("Error Failed to parse HTML Template", err)
+		}
+
 		expected := &events.CognitoEventUserPoolsCustomMessageResponse{
 			SMSMessage:   "認証コードは {####} です。",
-			EmailMessage: "メールアドレスを検証するには、次のリンクをクリックしてください。 http://localhost:3900/cognito/signup/confirm?code=123456789&sub=keitakn",
+			EmailMessage: body.String(),
 			EmailSubject: "サインアップ メールアドレスの確認をお願いします。",
 		}
 

--- a/message/signup-template.html
+++ b/message/signup-template.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>サインアップ</title>
+</head>
+<body>
+  <p>🐱以下のリンクをクリックしてサインアップを完了させて下さい。🐱</p>
+  <p>{{.ConfirmUrl}}</p>
+</body>
+</html>


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/12

# やった事
カスタムメッセージのTemplateをHTML形式に変更。

ついでにテスト実行時に `node_modules` の中まで参照してしまっていたので、除外するように変更。