### PR TITLE
カスタムメッセージLambdaのリファクタリングを実施

### DIFF
--- a/application/custom_message_scenario.go
+++ b/application/custom_message_scenario.go
@@ -17,6 +17,10 @@ type SignUpMessageBuildParams struct {
 	SubscribeNews bool
 }
 
+type ForgotPasswordMessageBuildParams struct {
+	Code string
+}
+
 type BuildMessage struct {
 	ConfirmUrl string
 }
@@ -37,6 +41,19 @@ func (s *CustomMessageScenario) BuildSignupMessage(p SignUpMessageBuildParams) (
 
 	var bodyBuffer bytes.Buffer
 	if err := s.Templates.ExecuteTemplate(&bodyBuffer, "signup-template.html", m); err != nil {
+		return "", err
+	}
+
+	return bodyBuffer.String(), nil
+}
+
+func (s *CustomMessageScenario) BuildForgotPasswordMessage(p ForgotPasswordMessageBuildParams) (body string, string error) {
+	m := BuildMessage{
+		ConfirmUrl: "http://localhost:3900/cognito/password/reset/confirm?code=" + p.Code + "&sub=" + s.AuthenticationTokensCreator.CognitoSub,
+	}
+
+	var bodyBuffer bytes.Buffer
+	if err := s.Templates.ExecuteTemplate(&bodyBuffer, "forgot-password-template.html", m); err != nil {
 		return "", err
 	}
 

--- a/application/custom_message_scenario.go
+++ b/application/custom_message_scenario.go
@@ -1,0 +1,44 @@
+package application
+
+import (
+	"bytes"
+	"github.com/keitakn/go-cognito-lambda/domain"
+	"html/template"
+)
+
+type CustomMessageScenario struct {
+	Templates                     *template.Template
+	AuthenticationTokenRepository domain.AuthenticationTokenRepository
+	AuthenticationTokensCreator   domain.AuthenticationTokensCreator
+}
+
+type SignUpMessageBuildParams struct {
+	Code          string
+	SubscribeNews bool
+}
+
+type BuildMessage struct {
+	ConfirmUrl string
+}
+
+func (s *CustomMessageScenario) BuildSignupMessage(p SignUpMessageBuildParams) (body string, string error) {
+	authenticationTokens, err := s.AuthenticationTokensCreator.Create()
+	if err != nil {
+		return "", err
+	}
+
+	if err := s.AuthenticationTokenRepository.Create(*authenticationTokens); err != nil {
+		return "", err
+	}
+
+	m := BuildMessage{
+		ConfirmUrl: "http://localhost:3900/cognito/signup/confirm?code=" + p.Code + "&sub=" + s.AuthenticationTokensCreator.CognitoSub + "&authenticationToken=" + authenticationTokens.Token,
+	}
+
+	var bodyBuffer bytes.Buffer
+	if err := s.Templates.ExecuteTemplate(&bodyBuffer, "signup-template.html", m); err != nil {
+		return "", err
+	}
+
+	return bodyBuffer.String(), nil
+}

--- a/application/custom_message_scenario_test.go
+++ b/application/custom_message_scenario_test.go
@@ -50,7 +50,7 @@ func TestHandler(t *testing.T) {
 		}
 
 		code := "123456"
-		res, err := scenario.BuildSignupMessage(SignUpMessageBuildParams{Code: "123456", SubscribeNews: true})
+		res, err := scenario.BuildSignupMessage(SignUpMessageBuildParams{Code: code, SubscribeNews: true})
 		if err != nil {
 			t.Fatal("Error failed to BuildSignupMessage", err)
 		}
@@ -62,6 +62,52 @@ func TestHandler(t *testing.T) {
 		expected, err := createExpectedSignUpMessage(m)
 		if err != nil {
 			t.Fatal("Error failed to createExpectedSignUpMessage", err)
+		}
+
+		if reflect.DeepEqual(res, expected) == false {
+			t.Error("\nActually: ", res, "\nExpected: ", expected)
+		}
+	})
+
+	t.Run("Successful BuildForgotPasswordMessage", func(t *testing.T) {
+		tokensCreator := domain.AuthenticationTokensCreator{
+			Token:         "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+			CognitoSub:    "0ef53af5-4eb9-4d2b-a939-8cb9d795512b",
+			SubscribeNews: true,
+			Time:          time.Now(),
+		}
+
+		tokens, err := tokensCreator.Create()
+		if err != nil {
+			t.Fatal("Error failed to Generate AuthenticationTokens", err)
+		}
+
+		repo := MockAuthenticationTokenRepository{
+			Token:          tokens.Token,
+			CognitoSub:     tokens.CognitoSub,
+			SubscribeNews:  tokens.SubscribeNews,
+			ExpirationTime: tokens.ExpirationTime,
+		}
+
+		scenario := CustomMessageScenario{
+			Templates:                     templates,
+			AuthenticationTokenRepository: &repo,
+			AuthenticationTokensCreator:   tokensCreator,
+		}
+
+		code := "987654"
+		res, err := scenario.BuildForgotPasswordMessage(ForgotPasswordMessageBuildParams{Code: code})
+		if err != nil {
+			t.Fatal("Error failed to BuildForgotPasswordMessage", err)
+		}
+
+		m := BuildMessage{
+			ConfirmUrl: "http://localhost:3900/cognito/password/reset/confirm?code=" + code + "&sub=" + tokensCreator.CognitoSub,
+		}
+
+		expected, err := createExpectedForgotPasswordMessageMessage(m)
+		if err != nil {
+			t.Fatal("Error failed to createExpectedForgotPasswordMessageMessage", err)
 		}
 
 		if reflect.DeepEqual(res, expected) == false {

--- a/application/custom_message_scenario_test.go
+++ b/application/custom_message_scenario_test.go
@@ -1,0 +1,71 @@
+package application
+
+import (
+	"github.com/keitakn/go-cognito-lambda/domain"
+	"html/template"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var templates *template.Template
+
+func TestMain(m *testing.M) {
+	signupTemplatePath := "../message/signup-template.html"
+	forgotPasswordTemplatePath := "../message/forgot-password-template.html"
+
+	templates = template.Must(template.ParseFiles(signupTemplatePath, forgotPasswordTemplatePath))
+
+	status := m.Run()
+
+	os.Exit(status)
+}
+
+func TestHandler(t *testing.T) {
+	t.Run("Successful BuildSignupMessage", func(t *testing.T) {
+		tokensCreator := domain.AuthenticationTokensCreator{
+			Token:         "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+			CognitoSub:    "0ef53af5-4eb9-4d2b-a939-8cb9d795512b",
+			SubscribeNews: true,
+			Time:          time.Now(),
+		}
+
+		tokens, err := tokensCreator.Create()
+		if err != nil {
+			t.Fatal("Error failed to Generate AuthenticationTokens", err)
+		}
+
+		repo := MockAuthenticationTokenRepository{
+			Token:          tokens.Token,
+			CognitoSub:     tokens.CognitoSub,
+			SubscribeNews:  tokens.SubscribeNews,
+			ExpirationTime: tokens.ExpirationTime,
+		}
+
+		scenario := CustomMessageScenario{
+			Templates:                     templates,
+			AuthenticationTokenRepository: &repo,
+			AuthenticationTokensCreator:   tokensCreator,
+		}
+
+		code := "123456"
+		res, err := scenario.BuildSignupMessage(SignUpMessageBuildParams{Code: "123456", SubscribeNews: true})
+		if err != nil {
+			t.Fatal("Error failed to BuildSignupMessage", err)
+		}
+
+		m := BuildMessage{
+			ConfirmUrl: "http://localhost:3900/cognito/signup/confirm?code=" + code + "&sub=" + tokensCreator.CognitoSub + "&authenticationToken=" + tokensCreator.Token,
+		}
+
+		expected, err := createExpectedSignUpMessage(m)
+		if err != nil {
+			t.Fatal("Error failed to createExpectedSignUpMessage", err)
+		}
+
+		if reflect.DeepEqual(res, expected) == false {
+			t.Error("\nActually: ", res, "\nExpected: ", expected)
+		}
+	})
+}

--- a/application/custom_message_scenario_test_helper.go
+++ b/application/custom_message_scenario_test_helper.go
@@ -1,0 +1,61 @@
+package application
+
+import (
+	"bytes"
+	"github.com/keitakn/go-cognito-lambda/domain"
+	"html/template"
+)
+
+type MockAuthenticationTokenRepository struct {
+	Token          string
+	CognitoSub     string
+	SubscribeNews  bool
+	ExpirationTime int64
+}
+
+func (r *MockAuthenticationTokenRepository) Create(item domain.AuthenticationTokens) error {
+	return nil
+}
+
+func (r *MockAuthenticationTokenRepository) FindByToken(token string) (*domain.AuthenticationTokens, error) {
+	return &domain.AuthenticationTokens{
+		Token:          token,
+		CognitoSub:     r.CognitoSub,
+		SubscribeNews:  r.SubscribeNews,
+		ExpirationTime: r.ExpirationTime,
+	}, nil
+}
+
+// SignupMessageカスタムメッセージのテスト用期待値を作成する
+func createExpectedSignUpMessage(m BuildMessage) (string, error) {
+	t := template.New("signup-template.html")
+
+	templatePath := "../message/signup-template.html"
+
+	templates := template.Must(t.ParseFiles(templatePath))
+
+	var bodyBuffer bytes.Buffer
+	err := templates.Execute(&bodyBuffer, m)
+	if err != nil {
+		return "", err
+	}
+
+	return bodyBuffer.String(), nil
+}
+
+// ForgotPasswordMessageカスタムメッセージのテスト用期待値を作成する
+func createExpectedForgotPasswordMessageMessage(m BuildMessage) (string, error) {
+	t := template.New("forgot-password-template.html")
+
+	templatePath := "../message/forgot-password-template.html"
+
+	templates := template.Must(t.ParseFiles(templatePath))
+
+	var bodyBuffer bytes.Buffer
+	err := templates.Execute(&bodyBuffer, m)
+	if err != nil {
+		return "", err
+	}
+
+	return bodyBuffer.String(), nil
+}

--- a/message/test_helper.go
+++ b/message/test_helper.go
@@ -1,47 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"github.com/aws/aws-lambda-go/events"
-	"html/template"
-	"os"
 )
-
-// テスト用の期待値を作成する
-func createExpectedSignUpMessage(m SignUpMessage) (*bytes.Buffer, error) {
-	t := template.New("signup-template.html")
-
-	currentDir, _ := os.Getwd()
-	templatePath := currentDir + "/signup-template.html"
-
-	templates := template.Must(t.ParseFiles(templatePath))
-
-	var bodyBuffer bytes.Buffer
-	err := templates.Execute(&bodyBuffer, m)
-	if err != nil {
-		return nil, err
-	}
-
-	return &bodyBuffer, nil
-}
-
-// ForgotPasswordMessageカスタムメッセージのテスト用期待値を作成する
-func createExpectedForgotPasswordMessageMessage(m ForgotPasswordMessage) (*bytes.Buffer, error) {
-	t := template.New("forgot-password-template.html")
-
-	currentDir, _ := os.Getwd()
-	templatePath := currentDir + "/forgot-password-template.html"
-
-	templates := template.Must(t.ParseFiles(templatePath))
-
-	var bodyBuffer bytes.Buffer
-	err := templates.Execute(&bodyBuffer, m)
-	if err != nil {
-		return nil, err
-	}
-
-	return &bodyBuffer, nil
-}
 
 type createUserPoolsCustomMessageEventParams struct {
 	TriggerSource string


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/30

# このPRの範囲
`CustomMessageScenario` を定義し、HTMLTemplateからHTML形式のmessageを生成するロジックを分離した。

これによって、メッセージ生成ロジックのテストは `CustomMessageScenario` のテストとして実装するようにした。

その結果として、`message/main_test.go` でメッセージの内容が正しいかどうかを担保する必要がなくなったので、`message/main_test.go` ではメッセージの内容ではなく、メッセージのタイトルだけ合っているかを見るだけにした。