### PR TITLE
Cognitoにサインアップ用の認証メールを送信するAPIを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ build:
 	GOOS=linux GOARCH=amd64 go build -o bin/createauthchallenge ./authchallenge/create/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/verifyauthchallenge ./authchallenge/verify/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/fetchcognitouser ./api/fetchcognitouser/main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/signup ./api/signup/main.go
 
 clean:
 	rm -rf ./bin

--- a/api/signup/main.go
+++ b/api/signup/main.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/keitakn/go-cognito-lambda/infrastructure"
+)
+
+type RequestBody struct {
+	UserPoolClientId string `json:"userPoolClientId"`
+	Email            string `json:"email"`
+	Password         string `json:"password"`
+	Name             string `json:"name"`
+}
+
+type ResponseCreatedBody struct {
+	CognitoSub string `json:"cognitoSub"`
+}
+
+type ResponseErrorBody struct {
+	Message string `json:"message"`
+}
+
+var svc *cognitoidentityprovider.CognitoIdentityProvider
+
+//nolint:gochecknoinits
+func init() {
+	sess, err := session.NewSession()
+	if err != nil {
+		// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
+		log.Fatalln(err)
+	}
+
+	svc = cognitoidentityprovider.New(sess, &aws.Config{
+		Region: aws.String(os.Getenv("REGION")),
+	})
+}
+
+func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGatewayV2HTTPResponse {
+	res := events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body:            string(resBodyJson),
+		IsBase64Encoded: false,
+	}
+
+	return res
+}
+
+func Handler(
+	ctx context.Context, req events.APIGatewayV2HTTPRequest,
+) (events.APIGatewayV2HTTPResponse, error) {
+	var reqBody RequestBody
+	if err := json.Unmarshal([]byte(req.Body), &reqBody); err != nil {
+		resBody := &ResponseErrorBody{Message: "Bad Request"}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, err
+	}
+
+	paramsSignUp := &cognitoidentityprovider.SignUpInput{
+		ClientId: aws.String(reqBody.UserPoolClientId),
+		Password: aws.String(reqBody.Password),
+		UserAttributes: []*cognitoidentityprovider.AttributeType{
+			{
+				Name:  aws.String("email"),
+				Value: aws.String(reqBody.Email),
+			},
+			{
+				Name:  aws.String("name"),
+				Value: aws.String(reqBody.Name),
+			},
+		},
+		Username: aws.String(reqBody.Email),
+	}
+
+	respSignUp, err := svc.SignUp(paramsSignUp)
+	if err != nil {
+		// TODO 本来はライブラリのエラーメッセージをそのまま返してはいけない、適切なエラーメッセージに変換して返す事を推奨
+		errorMessage := err.Error()
+
+		if errorMessage == "UsernameExistsException: An account with the given email already exists." {
+			errorMessage = "そのemailは既に利用されています。必要に応じて認証メールの再送APIを実行して下さい。"
+		}
+
+		resBody := &ResponseErrorBody{Message: errorMessage}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, nil
+	}
+
+	resBody := &ResponseCreatedBody{CognitoSub: *respSignUp.UserSub}
+	resBodyJson, _ := json.Marshal(resBody)
+
+	res := createApiGatewayV2Response(infrastructure.Created, resBodyJson)
+
+	return res, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/infrastructure/http_status_code.go
+++ b/infrastructure/http_status_code.go
@@ -2,6 +2,7 @@ package infrastructure
 
 const (
 	Ok                  int = 200
+	Created             int = 201
 	BadRequest          int = 400
 	NotFound            int = 404
 	InternalServerError int = 500

--- a/serverless.yml
+++ b/serverless.yml
@@ -118,6 +118,12 @@ functions:
       - httpApi:
           method: GET
           path: /users/{cognitoSub}
+  signUp:
+    handler: bin/signup
+    events:
+      - httpApi:
+          method: POST
+          path: /signup
 
 resources:
   Resources:


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/46

# やった事

Cognitoにサインアップを行い認証メールを送信するAPIを実装。

処理が成功するとステータスが `UNCONFIRMED` で登録される。

## リクエスト例

```
curl -v \
-X POST \
-H "Content-type: application/json" \
-d \
'
{
  "userPoolClientId": "権限があるUserPoolClientIDを指定",
  "email": "受信可能なメールアドレス",
  "password": "パスワードを指定",
  "name": "好きな名前を指定"
}
' \
https://${APIドメイン}/signup | jq
```

## 正常系レスポンス

```
< HTTP/2 201
< date: Thu, 11 Feb 2021 07:33:28 GMT
< content-type: application/json
< content-length: 133
< apigw-requestid: akeXQikUtjMEMXg=
<
{ [133 bytes data]
100   286  100   133  100   153     68     78  0:00:01  0:00:01 --:--:--   146
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
{
  "cognitoSub": "e4ac4c0e-e86e-4dc9-b9d9-faa743f8fda2"
}
```

## 異常系レスポンス

```
< HTTP/2 400
< date: Thu, 11 Feb 2021 07:33:28 GMT
< content-type: application/json
< content-length: 133
< apigw-requestid: akeXQikUtjMEMXg=
<
{ [133 bytes data]
100   286  100   133  100   153     68     78  0:00:01  0:00:01 --:--:--   146
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
{
  "message": "そのemailは既に利用されています。必要に応じて認証メールの再送APIを実行して下さい。"
}
```