### PR TITLE
Cognitoのサインアップを完了させるAPIを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ build:
 	GOOS=linux GOARCH=amd64 go build -o bin/verifyauthchallenge ./authchallenge/verify/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/fetchcognitouser ./api/fetchcognitouser/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/signup ./api/signup/main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/signupconfirm ./api/signupconfirm/main.go
 
 clean:
 	rm -rf ./bin

--- a/api/signupconfirm/main.go
+++ b/api/signupconfirm/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/keitakn/go-cognito-lambda/infrastructure"
+)
+
+type RequestBody struct {
+	UserPoolClientId string `json:"userPoolClientId"`
+	ConfirmationCode string `json:"confirmationCode"`
+	CognitoSub       string `json:"cognitoSub"`
+}
+
+type ResponseCreatedBody struct {
+	CognitoSub string `json:"cognitoSub"`
+}
+
+type ResponseErrorBody struct {
+	Message string `json:"message"`
+}
+
+var svc *cognitoidentityprovider.CognitoIdentityProvider
+
+//nolint:gochecknoinits
+func init() {
+	sess, err := session.NewSession()
+	if err != nil {
+		// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
+		log.Fatalln(err)
+	}
+
+	svc = cognitoidentityprovider.New(sess, &aws.Config{
+		Region: aws.String(os.Getenv("REGION")),
+	})
+}
+
+func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGatewayV2HTTPResponse {
+	res := events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body:            string(resBodyJson),
+		IsBase64Encoded: false,
+	}
+
+	return res
+}
+
+func Handler(
+	ctx context.Context, req events.APIGatewayV2HTTPRequest,
+) (events.APIGatewayV2HTTPResponse, error) {
+	var reqBody RequestBody
+	if err := json.Unmarshal([]byte(req.Body), &reqBody); err != nil {
+		resBody := &ResponseErrorBody{Message: "Bad Request"}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, err
+	}
+
+	input := &cognitoidentityprovider.ConfirmSignUpInput{
+		ClientId:         aws.String(reqBody.UserPoolClientId),
+		Username:         aws.String(reqBody.CognitoSub),
+		ConfirmationCode: aws.String(reqBody.ConfirmationCode),
+	}
+
+	_, err := svc.ConfirmSignUp(input)
+	if err != nil {
+		// TODO 本来はライブラリのエラーメッセージをそのまま返してはいけない、適切なエラーメッセージに変換して返す事を推奨
+		errorMessage := err.Error()
+
+		resBody := &ResponseErrorBody{Message: errorMessage}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, nil
+	}
+
+	resBody := &ResponseCreatedBody{CognitoSub: reqBody.CognitoSub}
+	resBodyJson, _ := json.Marshal(resBody)
+
+	res := createApiGatewayV2Response(infrastructure.Ok, resBodyJson)
+
+	return res, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/api/signupconfirm/main.go
+++ b/api/signupconfirm/main.go
@@ -77,8 +77,18 @@ func Handler(
 
 	_, err := svc.ConfirmSignUp(input)
 	if err != nil {
-		// TODO 本来はライブラリのエラーメッセージをそのまま返してはいけない、適切なエラーメッセージに変換して返す事を推奨
-		errorMessage := err.Error()
+		errorMessage := ""
+
+		switch errorMessage {
+		case "CodeMismatchException: Invalid verification code provided, please try again.":
+			errorMessage = "確認コードが一致しません、もう一度試して下さい。"
+		case "ExpiredCodeException: Invalid code provided, please request a code again.":
+			// 違うCognitoSubが指定された場合でもこのエラーメッセージが返ってくる
+			errorMessage = "確認コードが無効、または有効期限切れです。"
+		default:
+			// TODO 本来はライブラリのエラーメッセージをそのまま返してはいけない、適切なエラーメッセージに変換して返す事を推奨
+			errorMessage = err.Error()
+		}
 
 		resBody := &ResponseErrorBody{Message: errorMessage}
 		resBodyJson, _ := json.Marshal(resBody)

--- a/serverless.yml
+++ b/serverless.yml
@@ -124,6 +124,12 @@ functions:
       - httpApi:
           method: POST
           path: /signup
+  signUpConfirm:
+    handler: bin/signupconfirm
+    events:
+      - httpApi:
+          method: PATCH
+          path: /signup/confirm
 
 resources:
   Resources:


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/47

# やった事
Cognitoのサインアップを完了させるAPIの実装を行った。

このAPIを呼び出す前に https://github.com/keitakn/go-cognito-lambda/pull/50 で作成したAPIを呼び出しておく必要がある。

## リクエスト例

```
curl -v \
-X PATCH \
-H "Content-type: application/json" \
-d \
'
{
  "userPoolClientId": "権限があるUserPoolClientIDを指定 /signup で指定した物と同じ値を指定する",
  "ConfirmationCode": "認証メール内に記載された確認コード 6桁の数字だが文字列型で渡す必要がある",
  "cognitoSub": "認証メール内に記載されたCognitoUserの識別子"
}
' \
https://${APIドメイン}/signup/confirm | jq
```

## 正常系レスポンス

```
< HTTP/2 200
< date: Fri, 12 Feb 2021 02:10:45 GMT
< content-type: application/json
< content-length: 53
< apigw-requestid: anCB6jfUtjMEMSA=
<
{ [53 bytes data]
100   197  100    53  100   144    284    774 --:--:-- --:--:-- --:--:--  1059
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
{
  "cognitoSub": "39a1ddaa-2bea-4662-b595-874e67eb28a7"
}
```

## 異常系レスポンス

```
< HTTP/2 400
< date: Fri, 12 Feb 2021 02:13:03 GMT
< content-type: application/json
< content-length: 87
< apigw-requestid: anCXYhTHtjMEJgA=
<
{ [87 bytes data]
100   231  100    87  100   144    213    352 --:--:-- --:--:-- --:--:--   564
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
{
  "message": "ExpiredCodeException: Invalid code provided, please request a code again."
}
```