### PR TITLE
パスワードリセットの申請用APIを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ build:
 	GOOS=linux GOARCH=amd64 go build -o bin/signup ./api/signup/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/signupconfirm ./api/signupconfirm/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/signinpassword ./api/signinpassword/main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/passwordreset ./api/passwordreset/main.go
 
 clean:
 	rm -rf ./bin

--- a/api/passwordreset/main.go
+++ b/api/passwordreset/main.go
@@ -89,7 +89,7 @@ func Handler(
 		resBody := &ResponseErrorBody{Message: errorMessage}
 		resBodyJson, _ := json.Marshal(resBody)
 
-		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+		res := createApiGatewayV2Response(infrastructure.InternalServerError, resBodyJson)
 
 		return res, nil
 	}

--- a/api/passwordreset/main.go
+++ b/api/passwordreset/main.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/keitakn/go-cognito-lambda/infrastructure"
+)
+
+type RequestBody struct {
+	UserPoolClientId string `json:"userPoolClientId"`
+	Email            string `json:"email"`
+}
+
+type ResponseErrorBody struct {
+	Message string `json:"message"`
+}
+
+var svc *cognitoidentityprovider.CognitoIdentityProvider
+
+//nolint:gochecknoinits
+func init() {
+	sess, err := session.NewSession()
+	if err != nil {
+		// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
+		log.Fatalln(err)
+	}
+
+	svc = cognitoidentityprovider.New(sess, &aws.Config{
+		Region: aws.String(os.Getenv("REGION")),
+	})
+}
+
+func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGatewayV2HTTPResponse {
+	res := events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body:            string(resBodyJson),
+		IsBase64Encoded: false,
+	}
+
+	return res
+}
+
+func createApiGatewayV2NoContentResponse() events.APIGatewayV2HTTPResponse {
+	res := events.APIGatewayV2HTTPResponse{
+		StatusCode: infrastructure.NoContent,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		IsBase64Encoded: false,
+	}
+
+	return res
+}
+
+func Handler(
+	ctx context.Context, req events.APIGatewayV2HTTPRequest,
+) (events.APIGatewayV2HTTPResponse, error) {
+	var reqBody RequestBody
+	if err := json.Unmarshal([]byte(req.Body), &reqBody); err != nil {
+		resBody := &ResponseErrorBody{Message: "Bad Request"}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, err
+	}
+
+	input := &cognitoidentityprovider.ForgotPasswordInput{
+		ClientId: aws.String(reqBody.UserPoolClientId),
+		Username: aws.String(reqBody.Email),
+	}
+
+	_, err := svc.ForgotPassword(input)
+	if err != nil {
+		// TODO 本来はライブラリのエラーメッセージをそのまま返してはいけない、適切なエラーメッセージに変換して返す事を推奨
+		errorMessage := err.Error()
+
+		resBody := &ResponseErrorBody{Message: errorMessage}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, nil
+	}
+
+	res := createApiGatewayV2NoContentResponse()
+
+	return res, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/infrastructure/http_status_code.go
+++ b/infrastructure/http_status_code.go
@@ -3,6 +3,7 @@ package infrastructure
 const (
 	Ok                  int = 200
 	Created             int = 201
+	NoContent           int = 204
 	BadRequest          int = 400
 	NotFound            int = 404
 	InternalServerError int = 500

--- a/serverless.yml
+++ b/serverless.yml
@@ -136,6 +136,12 @@ functions:
       - httpApi:
           method: POST
           path: /signin/password
+  passwordReset:
+    handler: bin/passwordreset
+    events:
+      - httpApi:
+          method: POST
+          path: /password/reset
 
 resources:
   Resources:


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/48

# やった事

パスワードリセットを行う最初の手続きで利用するAPIを実装。

これを行うとパスワードリセット用の認証メールが送信される。

# リクエスト例

```
curl -v \
-X POST \
-H "Content-type: application/json" \
-d \
'
{
  "userPoolClientId": "権限があるUserPoolClientIDを指定",
  "email": "UserPoolに登録されているメールアドレスを指定"
}
' \
https://${APIドメイン}/password/reset | jq
```

# 正常系レスポンス

204なのでレスポンスはなしです。

```
< HTTP/2 204
< date: Fri, 12 Feb 2021 02:13:03 GMT
< content-type: application/json
< content-length: 87
< apigw-requestid: anCXYhTHtjMEJgA=
<
{ [87 bytes data]
100   231  100    87  100   144    213    352 --:--:-- --:--:-- --:--:--   564
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
```

# 異常系レスポンス

仮に存在しないメールアドレスを指定しても正常終了するので、エラーが発生するケースは稀です。

エラー発生時はAWS Cognitoで障害が発生していると判断しても良さそう。

```
< HTTP/2 500
< date: Fri, 12 Feb 2021 02:13:03 GMT
< content-type: application/json
< content-length: 87
< apigw-requestid: anCXYhTHtjMEJgA=
<
{ [87 bytes data]
100   231  100    87  100   144    213    352 --:--:-- --:--:-- --:--:--   564
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
{
  "message": "エラーメッセージ"
}
```