### PR TITLE
Cognitoのパスワードリセットを完了させるAPIを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 	GOOS=linux GOARCH=amd64 go build -o bin/signupconfirm ./api/signupconfirm/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/signinpassword ./api/signinpassword/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/passwordreset ./api/passwordreset/main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/passwordresetconfirm ./api/passwordresetconfirm/main.go
 
 clean:
 	rm -rf ./bin

--- a/api/passwordresetconfirm/main.go
+++ b/api/passwordresetconfirm/main.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/keitakn/go-cognito-lambda/infrastructure"
+)
+
+type RequestBody struct {
+	UserPoolClientId string `json:"userPoolClientId"`
+	ConfirmationCode string `json:"confirmationCode"`
+	CognitoSub       string `json:"cognitoSub"`
+	NewPassword      string `json:"newPassword"`
+}
+
+type ResponseErrorBody struct {
+	Message string `json:"message"`
+}
+
+var svc *cognitoidentityprovider.CognitoIdentityProvider
+
+//nolint:gochecknoinits
+func init() {
+	sess, err := session.NewSession()
+	if err != nil {
+		// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
+		log.Fatalln(err)
+	}
+
+	svc = cognitoidentityprovider.New(sess, &aws.Config{
+		Region: aws.String(os.Getenv("REGION")),
+	})
+}
+
+func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGatewayV2HTTPResponse {
+	res := events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body:            string(resBodyJson),
+		IsBase64Encoded: false,
+	}
+
+	return res
+}
+
+func createApiGatewayV2NoContentResponse() events.APIGatewayV2HTTPResponse {
+	res := events.APIGatewayV2HTTPResponse{
+		StatusCode: infrastructure.NoContent,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		IsBase64Encoded: false,
+	}
+
+	return res
+}
+
+func Handler(
+	ctx context.Context, req events.APIGatewayV2HTTPRequest,
+) (events.APIGatewayV2HTTPResponse, error) {
+	var reqBody RequestBody
+	if err := json.Unmarshal([]byte(req.Body), &reqBody); err != nil {
+		resBody := &ResponseErrorBody{Message: "Bad Request"}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, err
+	}
+
+	input := &cognitoidentityprovider.ConfirmForgotPasswordInput{
+		ClientId:         aws.String(reqBody.UserPoolClientId),
+		Username:         aws.String(reqBody.CognitoSub),
+		Password:         aws.String(reqBody.NewPassword),
+		ConfirmationCode: aws.String(reqBody.ConfirmationCode),
+	}
+
+	_, err := svc.ConfirmForgotPassword(input)
+	if err != nil {
+		errorMessage := err.Error()
+
+		switch errorMessage {
+		case "CodeMismatchException: Invalid verification code provided, please try again.":
+			errorMessage = "確認コードが一致しません、もう一度試して下さい。"
+		case "ExpiredCodeException: Invalid code provided, please request a code again.":
+			// 違うCognitoSubが指定された場合でもこのエラーメッセージが返ってくる
+			errorMessage = "確認コードが無効、または有効期限切れです。"
+		default:
+			// TODO 本来はライブラリのエラーメッセージをそのまま返してはいけない、適切なエラーメッセージに変換して返す事を推奨
+			errorMessage = err.Error()
+		}
+
+		resBody := &ResponseErrorBody{Message: errorMessage}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, nil
+	}
+
+	res := createApiGatewayV2NoContentResponse()
+
+	return res, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -142,6 +142,12 @@ functions:
       - httpApi:
           method: POST
           path: /password/reset
+  passwordResetConfirm:
+    handler: bin/passwordresetconfirm
+    events:
+      - httpApi:
+          method: PATCH
+          path: /password/reset/confirm
 
 resources:
   Resources:


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/49

# やった事
パスワードを忘れたユーザーが新しいパスワードに変更する為のAPI。

https://github.com/keitakn/go-cognito-lambda/pull/54 で作成したAPIを使って認証メールを受け取っている前提になります。

# リクエスト例

```
curl -v \
-X PATCH \
-H "Content-type: application/json" \
-d \
'
{
  "userPoolClientId": "権限があるUserPoolClientIDを指定",
  "confirmationCode": "認証メール内に記載された確認コード 6桁の数字だが文字列型で渡す必要がある",
  "cognitoSub": "認証メール内に記載されたCognitoUserの識別子",
  "newPassword": "新しいパスワード"
}
' \
https://dev-cognito-admin-api.keitakn.de/password/reset/confirm | jq
```

# 正常系レスポンス

204なのでレスポンスはなしです。

```
< HTTP/2 204
< date: Fri, 12 Feb 2021 02:13:03 GMT
< content-type: application/json
< content-length: 87
< apigw-requestid: anCXYhTHtjMEJgA=
<
{ [87 bytes data]
100   231  100    87  100   144    213    352 --:--:-- --:--:-- --:--:--   564
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
```

# 異常系レスポンス

バリデーションエラーの場合は `ConfirmForgotPassword` から以下のエラーが返ってくる。

`"InvalidParameter: 1 validation error(s) found.\n- minimum field size of 6, ConfirmForgotPasswordInput.Password.\n"`

これだけで判定するのは厳しいので、バリデーションエラーをクライアント側に返したい場合は自前でバリデーション処理を書いたほうが無難。