### PR TITLE
サインアップ認証メール再送信APIの実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 	GOOS=linux GOARCH=amd64 go build -o bin/signinpassword ./api/signinpassword/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/passwordreset ./api/passwordreset/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/passwordresetconfirm ./api/passwordresetconfirm/main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/signupresend ./api/signupresend/main.go
 
 clean:
 	rm -rf ./bin

--- a/api/signupresend/main.go
+++ b/api/signupresend/main.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
+	"github.com/keitakn/go-cognito-lambda/infrastructure"
+)
+
+type RequestBody struct {
+	UserPoolClientId string `json:"userPoolClientId"`
+	Email            string `json:"email"`
+	Name             string `json:"name"`
+}
+
+type ResponseCreatedBody struct {
+	CognitoSub string `json:"cognitoSub"`
+}
+
+type ResponseErrorBody struct {
+	Message string `json:"message"`
+}
+
+var svc *cognitoidentityprovider.CognitoIdentityProvider
+
+//nolint:gochecknoinits
+func init() {
+	sess, err := session.NewSession()
+	if err != nil {
+		// TODO ここでエラーが発生した場合、致命的な問題が起きているのでちゃんとしたログを出すように改修する
+		log.Fatalln(err)
+	}
+
+	svc = cognitoidentityprovider.New(sess, &aws.Config{
+		Region: aws.String(os.Getenv("REGION")),
+	})
+}
+
+func createApiGatewayV2Response(statusCode int, resBodyJson []byte) events.APIGatewayV2HTTPResponse {
+	res := events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body:            string(resBodyJson),
+		IsBase64Encoded: false,
+	}
+
+	return res
+}
+
+func fetchCognitoUserByEmail(email string) (*cognitoidentityprovider.AdminGetUserOutput, error) {
+	userPoolId := os.Getenv("TARGET_USER_POOL_ID")
+	input := &cognitoidentityprovider.AdminGetUserInput{
+		UserPoolId: &userPoolId,
+		Username:   &email,
+	}
+
+	user, err := svc.AdminGetUser(input)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
+
+func mightUpdateUserAttributes(reqBody RequestBody, user *cognitoidentityprovider.AdminGetUserOutput) error {
+	if !*user.Enabled {
+		return nil
+	}
+
+	// 認証がまだの場合だけユーザー情報をアップデートする
+	if *user.UserStatus == "UNCONFIRMED" {
+		updateUserAttributesInput := &cognitoidentityprovider.AdminUpdateUserAttributesInput{
+			UserPoolId: aws.String(os.Getenv("TARGET_USER_POOL_ID")),
+			Username:   aws.String(reqBody.Email),
+			UserAttributes: []*cognitoidentityprovider.AttributeType{
+				{
+					Name:  aws.String("name"),
+					Value: aws.String(reqBody.Name),
+				},
+			},
+		}
+
+		if _, err := svc.AdminUpdateUserAttributes(updateUserAttributesInput); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func Handler(
+	ctx context.Context, req events.APIGatewayV2HTTPRequest,
+) (events.APIGatewayV2HTTPResponse, error) {
+	var reqBody RequestBody
+	if err := json.Unmarshal([]byte(req.Body), &reqBody); err != nil {
+		resBody := &ResponseErrorBody{Message: "Bad Request"}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, err
+	}
+
+	user, err := fetchCognitoUserByEmail(reqBody.Email)
+	if err != nil {
+		resBody := &ResponseErrorBody{Message: "User Not Found"}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, nil
+	}
+
+	if err := mightUpdateUserAttributes(reqBody, user); err != nil {
+		// この条件分岐に入る事はシステム障害等以外はあり得ないので、500エラーを返す
+		resBody := &ResponseErrorBody{Message: "予期せぬエラーが発生しました。時間が経ってから再度お試し下さい。"}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.InternalServerError, resBodyJson)
+
+		return res, nil
+	}
+
+	input := &cognitoidentityprovider.ResendConfirmationCodeInput{
+		ClientId: aws.String(reqBody.UserPoolClientId),
+		Username: aws.String(reqBody.Email),
+	}
+
+	_, err = svc.ResendConfirmationCode(input)
+	if err != nil {
+		// TODO 本来はライブラリのエラーメッセージをそのまま返してはいけない、適切なエラーメッセージに変換して返す事を推奨
+		errorMessage := err.Error()
+
+		if errorMessage == "UsernameExistsException: An account with the given email already exists." {
+			errorMessage = "そのemailは既に利用されています。必要に応じて認証メールの再送APIを実行して下さい。"
+		}
+
+		resBody := &ResponseErrorBody{Message: errorMessage}
+		resBodyJson, _ := json.Marshal(resBody)
+
+		res := createApiGatewayV2Response(infrastructure.BadRequest, resBodyJson)
+
+		return res, nil
+	}
+
+	resBody := &ResponseCreatedBody{CognitoSub: *user.Username}
+	resBodyJson, _ := json.Marshal(resBody)
+
+	res := createApiGatewayV2Response(infrastructure.Ok, resBodyJson)
+
+	return res, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -124,6 +124,12 @@ functions:
       - httpApi:
           method: POST
           path: /signup
+  signUpResend:
+    handler: bin/signupresend
+    events:
+      - httpApi:
+          method: PATCH
+          path: /signup/resend
   signUpConfirm:
     handler: bin/signupconfirm
     events:


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/53

サインアップ用の認証メールを再送する為のAPIを実装。

https://github.com/keitakn/go-cognito-lambda/pull/50 のAPIで一度認証メールを送っているが、有効期限切れになった場合等に再送が必要な際に利用する。

# リクエスト例

```
curl -v \
-X PATCH \
-H "Content-type: application/json" \
-d \
'
{
  "userPoolClientId": "権限があるUserPoolClientIDを指定",
  "email": "UserPoolに登録されている、未認証ユーザーのメールアドレスを指定",
  "name": "UserPool上に登録される名前"
}
' \
https://${APIドメイン}/signup/resend | jq
```

# 正常系レスポンス

```
< HTTP/2 200
< date: Fri, 19 Feb 2021 08:58:16 GMT
< content-type: application/json
< content-length: 89
< apigw-requestid: a_CSQhXXtjMEMCA=
<
{ [89 bytes data]
100   208  100    89  100   119    340    455 --:--:-- --:--:-- --:--:--   793
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
{
  "cognitoSub": "968a2b46-af14-4bdb-bddc-1ae95097fbe0"
}
```

# 異常系レスポンス

```
< HTTP/2 400
< date: Fri, 19 Feb 2021 08:58:16 GMT
< content-type: application/json
< content-length: 89
< apigw-requestid: a_CSQhXXtjMEMCA=
<
{ [89 bytes data]
100   208  100    89  100   119    340    455 --:--:-- --:--:-- --:--:--   793
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
{
  "message": "LimitExceededException: Attempt limit exceeded, please try after some time."
}
```

# 補足情報

## CONFIRMEDのCognitoUserが本APIを呼び出すと発生するエラー

エラーメッセージが分かりにくい。

```
< HTTP/2 400
< date: Fri, 19 Feb 2021 08:58:16 GMT
< content-type: application/json
< content-length: 89
< apigw-requestid: a_CSQhXXtjMEMCA=
<
{ [89 bytes data]
100   208  100    89  100   119    340    455 --:--:-- --:--:-- --:--:--   793
* Connection #0 to host dev-cognito-admin-api.keitakn.de left intact
* Closing connection 0
{
  "message": "LimitExceededException: Attempt limit exceeded, please try after some time."
}
```

既に `CONFIRMED` の場合は再送信出来ない模様。

これは `Amplify. resendSignUp` とは少し異なる挙動で `Amplify. resendSignUp` の場合は再送信出来る。

## パスワードの上書きについて

以下のようにすればパスワードは上書き出来るが、かなり問題がある。

```
		adminSetUserPasswordInput := &cognitoidentityprovider.AdminSetUserPasswordInput{
			UserPoolId: aws.String(os.Getenv("TARGET_USER_POOL_ID")),
			Username:   aws.String(reqBody.Email),
			Password:   aws.String(reqBody.Password),
			Permanent:  aws.Bool(false),
		}

		if _, err := svc.AdminSetUserPassword(adminSetUserPasswordInput); err != nil {
			return err
		}
```

- `Permanent` を `false` に設定するとCognitoUserのステータスが `FORCE_CHANGE_PASSWORD` になる
- `Permanent` を `true` に設定するとCognitoUserのステータスが `CONFIRMED` になる

CognitoUserのステータスが `FORCE_CHANGE_PASSWORD` だとサインアップの完了に失敗してしまう。

CognitoUserのステータスが `CONFIRMED` だと実際にはメール認証が終わっていないのにサインアップが完了してしまいログイン出来る状態になってしまう。

よってこのAPIで行っている認証メール再送信時にパスワードを上書きする事は難しいと判断した。

このAPIの中で一時的にパスワードをどこかに保存しておいて、サインアップ完了時にそのパスワードで上書きする事は可能だとは思うが、それはパスワードを可逆方式の暗号形式で保存しなければいけない事を意味するので、このような機能は作らないほうが無難。