### PR TITLE
ユーザー移行Lambdaのサンプルコードを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build:
 	GOOS=linux GOARCH=amd64 go build -o bin/defineauthchallenge ./authchallenge/define/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/createauthchallenge ./authchallenge/create/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/verifyauthchallenge ./authchallenge/verify/main.go
+	GOOS=linux GOARCH=amd64 go build -o bin/migrateuser ./migrateuser/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/fetchcognitouser ./api/fetchcognitouser/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/signup ./api/signup/main.go
 	GOOS=linux GOARCH=amd64 go build -o bin/signupconfirm ./api/signupconfirm/main.go

--- a/migrateuser/main.go
+++ b/migrateuser/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// 検証用なのでメールアドレスが特定の値だったら移行対象と見なす
+func shouldMigrate(email string) bool {
+	return email == "keita.koga.work+migrateuser@gmail.com"
+}
+
+func Handler(event events.CognitoEventUserPoolsMigrateUser) (events.CognitoEventUserPoolsMigrateUser, error) {
+	if event.UserPoolID != os.Getenv("TARGET_USER_POOL_ID") {
+		return event, nil
+	}
+
+	// email_verifiedは文字列で設定する必要がある
+	emailVerified := "true"
+
+	// 認証が行われた際に呼ばれる
+	if event.TriggerSource == "UserMigration_Authentication" {
+		// 検証用なのでメールアドレスが特定の値だったら移行対象と見なす
+		// 本来はここで移行元の認証システムに認証を行い移行対象かどうかを判断する
+		if shouldMigrate(event.UserName) {
+			migrateUser := make(map[string]string)
+			migrateUser["email"] = event.UserName
+			migrateUser["email_verified"] = emailVerified
+
+			event.CognitoEventUserPoolsMigrateUserResponse.UserAttributes = migrateUser
+			event.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus = "CONFIRMED"
+			event.CognitoEventUserPoolsMigrateUserResponse.MessageAction = "SUPPRESS"
+
+			return event, nil
+		}
+	}
+
+	// パスワードリセットの認証メール送信時に呼ばれる
+	if event.TriggerSource == "UserMigration_ForgotPassword" {
+		// 検証用なのでメールアドレスが特定の値だったら移行対象と見なす
+		// 本来はここで移行元の認証システムに認証を行い移行対象かどうかを判断する
+		if shouldMigrate(event.UserName) {
+			migrateUser := make(map[string]string)
+			migrateUser["email"] = event.UserName
+			migrateUser["email_verified"] = emailVerified
+
+			event.CognitoEventUserPoolsMigrateUserResponse.UserAttributes = migrateUser
+			event.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus = "CONFIRMED"
+			event.CognitoEventUserPoolsMigrateUserResponse.MessageAction = "SUPPRESS"
+
+			return event, nil
+		}
+	}
+
+	return event, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/migrateuser/main_test.go
+++ b/migrateuser/main_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func TestMain(m *testing.M) {
+	status := m.Run()
+
+	os.Exit(status)
+}
+
+//nolint:funlen
+func TestHandler(t *testing.T) {
+	const expectedEmailVerified = "true"
+
+	const expectedFinalUserStatus = "CONFIRMED"
+
+	const expectedMessageAction = "SUPPRESS"
+
+	//nolint:dupl
+	t.Run("Successful user migration TriggerSource is UserMigration_Authentication", func(t *testing.T) {
+		eventHeader := &events.CognitoEventUserPoolsHeader{
+			UserPoolID:    os.Getenv("TARGET_USER_POOL_ID"),
+			TriggerSource: "UserMigration_Authentication",
+			UserName:      "keita.koga.work+migrateuser@gmail.com",
+		}
+
+		event := &events.CognitoEventUserPoolsMigrateUser{
+			CognitoEventUserPoolsHeader: *eventHeader,
+		}
+
+		handlerResult, err := Handler(*event)
+		if err != nil {
+			t.Fatal("Error failed to trigger with an invalid request", err)
+		}
+
+		expectedMigrateUser := make(map[string]string)
+		expectedMigrateUser["email"] = event.UserName
+		expectedMigrateUser["email_verified"] = expectedEmailVerified
+
+		if reflect.DeepEqual(
+			handlerResult.CognitoEventUserPoolsMigrateUserResponse.UserAttributes, expectedMigrateUser,
+		) == false {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.UserAttributes,
+				"\nExpected: ",
+				expectedMigrateUser,
+			)
+		}
+
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus != expectedFinalUserStatus {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus,
+				"\nExpected: ",
+				expectedFinalUserStatus,
+			)
+		}
+
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction != expectedMessageAction {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction,
+				"\nExpected: ",
+				expectedMessageAction,
+			)
+		}
+	})
+
+	//nolint:dupl
+	t.Run("Successful user migration TriggerSource is UserMigration_ForgotPassword", func(t *testing.T) {
+		eventHeader := &events.CognitoEventUserPoolsHeader{
+			UserPoolID:    os.Getenv("TARGET_USER_POOL_ID"),
+			TriggerSource: "UserMigration_ForgotPassword",
+			UserName:      "keita.koga.work+migrateuser@gmail.com",
+		}
+
+		event := &events.CognitoEventUserPoolsMigrateUser{
+			CognitoEventUserPoolsHeader: *eventHeader,
+		}
+
+		handlerResult, err := Handler(*event)
+		if err != nil {
+			t.Fatal("Error failed to trigger with an invalid request", err)
+		}
+
+		expectedMigrateUser := make(map[string]string)
+		expectedMigrateUser["email"] = event.UserName
+		expectedMigrateUser["email_verified"] = expectedEmailVerified
+
+		if reflect.DeepEqual(
+			handlerResult.CognitoEventUserPoolsMigrateUserResponse.UserAttributes, expectedMigrateUser,
+		) == false {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.UserAttributes,
+				"\nExpected: ",
+				expectedMigrateUser,
+			)
+		}
+
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus != expectedFinalUserStatus {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus,
+				"\nExpected: ",
+				expectedFinalUserStatus,
+			)
+		}
+
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction != expectedMessageAction {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction,
+				"\nExpected: ",
+				expectedMessageAction,
+			)
+		}
+	})
+
+	t.Run("The user will not be migrated, Because the UserPoolID is different", func(t *testing.T) {
+		eventHeader := &events.CognitoEventUserPoolsHeader{
+			UserPoolID:    "UNKNOWN_USER_POOL_ID",
+			TriggerSource: "UserMigration_ForgotPassword",
+			UserName:      "keita.koga.work+migrateuser@gmail.com",
+		}
+
+		event := &events.CognitoEventUserPoolsMigrateUser{
+			CognitoEventUserPoolsHeader: *eventHeader,
+		}
+
+		handlerResult, err := Handler(*event)
+		if err != nil {
+			t.Fatal("Error failed to trigger with an invalid request", err)
+		}
+
+		expectedFinalUserStatus := ""
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus != expectedFinalUserStatus {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus,
+				"\nExpected: ",
+				expectedFinalUserStatus,
+			)
+		}
+
+		expectedMessageAction := ""
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction != expectedMessageAction {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction,
+				"\nExpected: ",
+				expectedMessageAction,
+			)
+		}
+	})
+
+	t.Run("The user will not be migrated, Because the TriggerSource is different", func(t *testing.T) {
+		eventHeader := &events.CognitoEventUserPoolsHeader{
+			UserPoolID:    os.Getenv("TARGET_USER_POOL_ID"),
+			TriggerSource: "Unknown_TriggerSource",
+			UserName:      "keita.koga.work+migrateuser@gmail.com",
+		}
+
+		event := &events.CognitoEventUserPoolsMigrateUser{
+			CognitoEventUserPoolsHeader: *eventHeader,
+		}
+
+		handlerResult, err := Handler(*event)
+		if err != nil {
+			t.Fatal("Error failed to trigger with an invalid request", err)
+		}
+
+		expectedFinalUserStatus := ""
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus != expectedFinalUserStatus {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus,
+				"\nExpected: ",
+				expectedFinalUserStatus,
+			)
+		}
+
+		expectedMessageAction := ""
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction != expectedMessageAction {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction,
+				"\nExpected: ",
+				expectedMessageAction,
+			)
+		}
+	})
+
+	t.Run("The user will not be migrated, Because the UserName is different", func(t *testing.T) {
+		eventHeader := &events.CognitoEventUserPoolsHeader{
+			UserPoolID:    os.Getenv("TARGET_USER_POOL_ID"),
+			TriggerSource: "UserMigration_Authentication",
+			UserName:      "keita.koga.work@gmail.com",
+		}
+
+		event := &events.CognitoEventUserPoolsMigrateUser{
+			CognitoEventUserPoolsHeader: *eventHeader,
+		}
+
+		handlerResult, err := Handler(*event)
+		if err != nil {
+			t.Fatal("Error failed to trigger with an invalid request", err)
+		}
+
+		expectedFinalUserStatus := ""
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus != expectedFinalUserStatus {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.FinalUserStatus,
+				"\nExpected: ",
+				expectedFinalUserStatus,
+			)
+		}
+
+		expectedMessageAction := ""
+		if handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction != expectedMessageAction {
+			t.Error(
+				"\nActually: ",
+				handlerResult.CognitoEventUserPoolsMigrateUserResponse.MessageAction,
+				"\nExpected: ",
+				expectedMessageAction,
+			)
+		}
+	})
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -102,6 +102,13 @@ functions:
           pool: ${env:TRIGGER_USER_POOL_NAME}
           trigger: VerifyAuthChallengeResponse
           existing: true
+  migrateUser:
+    handler: bin/migrateuser
+    events:
+      - cognitoUserPool:
+          pool: ${env:TRIGGER_USER_POOL_NAME}
+          trigger: UserMigration
+          existing: true
   changePassword:
     handler: bin/changepassword
     events:
@@ -190,6 +197,15 @@ resources:
         Action: "lambda:InvokeFunction"
         FunctionName:
           Fn::GetAtt: [ "VerifyAuthChallengeLambdaFunction", "Arn"]
+        Principal: "cognito-idp.amazonaws.com"
+        SourceArn:
+          Fn::Join: [ "", [ "arn:aws:cognito-idp", ":", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":", "userpool/", "${env:TARGET_USER_POOL_ID}" ] ]
+    OnCognitoMigrateUserLambdaPermission:
+      Type: "AWS::Lambda::Permission"
+      Properties:
+        Action: "lambda:InvokeFunction"
+        FunctionName:
+          Fn::GetAtt: [ "MigrateUserLambdaFunction", "Arn"]
         Principal: "cognito-idp.amazonaws.com"
         SourceArn:
           Fn::Join: [ "", [ "arn:aws:cognito-idp", ":", Ref: "AWS::Region", ":", Ref: "AWS::AccountId", ":", "userpool/", "${env:TARGET_USER_POOL_ID}" ] ]


### PR DESCRIPTION
# issueURL
https://github.com/keitakn/go-cognito-lambda/issues/24

# やった事

別の認証基盤からUserPoolにデータを移行する際に実装が必要なユーザー移行Lambdaの実装とその動作タイミングを調査した。

ユーザー移行LambdaのAWSの公式ドキュメントは下記

https://docs.aws.amazon.com/ja_jp/cognito/latest/developerguide/user-pool-lambda-migrate-user.html

## ユーザー移行Lambdaのトリガー

パスワード認証の際とパスワードリセット用の手続きを行ったタイミングで実行される。

本プロジェクトで以下の2つのAPIを実行した際に正常に動作する事を確認。

- https://github.com/keitakn/go-cognito-lambda/pull/52
- https://github.com/keitakn/go-cognito-lambda/pull/54

## ユーザー移行Lambdaの動作タイミングについて確認
一度移行されたユーザーの場合はユーザー移行Lambdaのほうで冪等性を担保してくれるようなので、実装側で冪等性を担保する必要はなさそう。

- パスワード認証で移行したユーザーが入力したパスワードがCognitoUserPoolのパスワードポリシーを満たしていない場合は移行に失敗する
- パスワードリセットの場合はパスワードが設定されていない状態になるので、パスワードリセットを完了させるまではログイン出来ない状態になる